### PR TITLE
[BUGFIX] Fixed choosing of inaccessible root template

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -81,7 +81,7 @@ class Tx_Fluidcontent_Service_ConfigurationService extends Tx_Flux_Service_Confi
 		}
 		$pageUid = intval(t3lib_div::_GP('id'));
 		if ($pageUid < 1) {
-			$firstPageWithRootTemplate = array_shift($GLOBALS['TYPO3_DB']->exec_SELECTgetRows('pid', 'sys_template t', 't.root = 1 AND deleted = 0 AND hidden = 0  AND starttime<='.$GLOBALS['SIM_ACCESS_TIME'].' AND (endtime=0 OR endtime>'.$GLOBALS['SIM_ACCESS_TIME'].')'));
+			$firstPageWithRootTemplate = array_shift($GLOBALS['TYPO3_DB']->exec_SELECTgetRows('pid', 'sys_template t', 't.root = 1 AND deleted = 0 AND hidden = 0  AND starttime<=' . $GLOBALS['SIM_ACCESS_TIME'] . ' AND (endtime=0 OR endtime>' . $GLOBALS['SIM_ACCESS_TIME'] . ')'));
 			if (TRUE === is_array($firstPageWithRootTemplate)) {
 				$pageUid = $firstPageWithRootTemplate['pid'];
 			} else {


### PR DESCRIPTION
Fixed that Tx_Fluidcontent_Service_ConfigurationService->writeCachedConfigurationIfMissing() choose root templates that are deleted or otherwise inaccessible.
