### PR TITLE
Provide file extension parameter to select only HTML files

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -122,7 +122,7 @@ class Tx_Fluidcontent_Service_ConfigurationService extends Tx_Flux_Service_Confi
 			$templatePathSet = Tx_Flux_Utility_Path::translatePath($templatePathSet);
 			$templateRootPath = $templatePathSet['templateRootPath'];
 			$files = array();
-			$files = t3lib_div::getAllFilesAndFoldersInPath($files, $templateRootPath, '');
+			$files = t3lib_div::getAllFilesAndFoldersInPath($files, $templateRootPath, 'html');
 			if (count($files) > 0) {
 				foreach ($files as $templateFilename) {
 					$fileRelPath = substr($templateFilename, strlen($templateRootPath));


### PR DESCRIPTION
Without file extension parameter getAllFilesAndFoldersInPath finds all
files and folders in the given path. Therefore it also includes files
you don't want to use as template files like swap files created by
several editors. E.g. a present .swp file leads to strange behavior as
your configuration gets corrupted.

There may be more extensions than HTML, but so far it's the only I can think of.
