### PR TITLE
[BUGFIX] Call ancestor method "message"

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -317,7 +317,7 @@ class Tx_Fluidcontent_Service_ConfigurationService extends Tx_Flux_Service_FluxS
 	 * @return void
 	 */
 	protected function sendDisabledContentWarning($templatePathAndFilename) {
-		$this->configurationService->message('Disabled Fluid Content Element: ' . $templatePathAndFilename , t3lib_div::SYSLOG_SEVERITY_NOTICE);
+		$this->message('Disabled Fluid Content Element: ' . $templatePathAndFilename , t3lib_div::SYSLOG_SEVERITY_NOTICE);
 	}
 
 }


### PR DESCRIPTION
The class had an outdated reference to a 
configuration service.
