### PR TITLE
[TASK] Huge performance boost in page tree operations

### DIFF
--- a/Classes/Provider/ContentConfigurationProvider.php
+++ b/Classes/Provider/ContentConfigurationProvider.php
@@ -146,7 +146,10 @@ class Tx_Fluidcontent_Provider_ContentConfigurationProvider extends Tx_Flux_Prov
 	 *
 	 * @return void
 	 */
-	public function clearCacheCommand() {
+	public function clearCacheCommand($command = array()) {
+		if (TRUE === isset($command['uid'])) {
+			return;
+		}
 		if (file_exists(FLUIDCONTENT_TEMPFILE) === TRUE) {
 			unlink(FLUIDCONTENT_TEMPFILE);
 		}


### PR DESCRIPTION
The main reason for the sluggish page tree was an overly eager cache clearing. The following circumstances had an effect:
- Flux did not know about which type of cache clearing command was being dispatched an content lists need only be rebuilt on full cache clearing.
- Flux is dispatching the cache clearing command to every ConfigurationProvider so operating on the `pages` table caused `tt_content` providers to also trigger, including this one - combined with the first circumstance all FCE definitions would be cleared.
- This Provider rebuilds all content elements when all caches are cleared.

The result was that when operating on pages in the page tree (hiding, showing, moving - any operation that would imply one or more pages' caches being cleared) a log of unnecessary processing was being done. An early return greatly improves this by completely avoiding cache clearing when clearing the cache was not triggered manually.
