### PR TITLE
[BUGFIX] Order of legacy -> native view locations

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -80,10 +80,10 @@ class Tx_Fluidcontent_Service_ConfigurationService extends Tx_Flux_Service_FluxS
 			}
 		} else {
 			$nativeViewLocation = $this->getViewConfigurationForExtensionName($extensionName);
+			$merged = t3lib_div::array_merge_recursive_overrule($nativeViewLocation, $merged);
 			if (FALSE === isset($merged['extensionKey'])) {
-				$nativeViewLocation['extensionKey'] = t3lib_div::camelCaseToLowerCaseUnderscored($extensionName);
+				$merged['extensionKey'] = t3lib_div::camelCaseToLowerCaseUnderscored($extensionName);
 			}
-			$merged = t3lib_div::array_merge_recursive_overrule($merged, $nativeViewLocation);
 		}
 		self::$cache[$cacheKey] = $merged;
 		return $merged;


### PR DESCRIPTION
Prevents a (possibly empty) native view configuration from overwriting a legacy configuration. Which means that if any legacy method is used, it will take priority over the native view locations.

Fixes: #69
