### PR TITLE
[BUGFIX] Content Selector options werent filled in list view

### DIFF
--- a/Classes/Backend/ContentSelector.php
+++ b/Classes/Backend/ContentSelector.php
@@ -44,8 +44,17 @@ class Tx_Fluidcontent_Backend_ContentSelector {
 		$pageTypoScript = file_get_contents(PATH_site . 'typo3temp/.FED_CONTENT');
 		$tsParser = new t3lib_TSparser();
 		$conditions = new t3lib_matchCondition_backend();
+<<<<<<< HEAD
 		$currentPid = 0!==intval(t3lib_div::_GET('id')) ? t3lib_div::_GET('id') : $parameters['row']['pid'];
 		$conditions->setPageId(intval($currentPid));
+=======
+		$pageUid = t3lib_div::_GET('id');
+		$pageUid = intval($pageUid);
+		if (0 === $pageUid) {
+		    $pageUid = intval($parameters['row']['pid']);
+		}
+		$conditions->setPageId($pageUid);
+>>>>>>> [BUGFIX] Content Selector options werent filled in list view
 		$tsParser->parse($pageTypoScript, $conditions);
 		$setup = $tsParser->setup['mod.']['wizards.']['newContentElement.']['wizardItems.'];
 		if (FALSE === is_array($tsParser->setup['mod.']['wizards.']['newContentElement.']['wizardItems.'])) {


### PR DESCRIPTION
Retrieving Page Id with t3lib_div::_GET('id') is not possible in list view.

We have to retrieve and set the current page id on conditions object that the conditions in .FED_CONTENT (like PIDinRootline) match correctly.

So to retrieve Page ID also in list view we lookup the pid where the parent record is stored.

Also for new records there is no problem with retrieving page id from this source because when the Content type is changed to "Fluid content" a reload is forced - after that the page id is available in parameters!
