### PR TITLE
[BUGFIX] Only clear cache when "Clear configuration cache" is pressed

### DIFF
--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -162,6 +162,10 @@ class ContentProvider extends FluxContentProvider implements ProviderInterface {
 	 * @return void
 	 */
 	public function clearCacheCommand($command = array()) {
+		// only empty the cache when "clear configuration cache is pressed"
+		if ('temp_cached' !== $command['cacheCmd'])) {
+			return;
+		}
 		if (TRUE === isset($command['uid'])) {
 			return;
 		}


### PR DESCRIPTION
Hey,

this is the mentioned patch. Removing FLUIDCONTENT_TEMPFILE results in rebuilding the file, which takes two minutes (our version even does that in the current process). as far as I can see, rebuilding the file is not necessary when clearing "all caches" or the frontend cache. If so, let's find another solution.

Also have a look at the caching framework and a new addition for 6.2, https://review.typo3.org/26829, where caches like ext_localconf.php\* is stored in a group "system" that is only cleared when installing an extension/updating the sytem or manually clearing the temporary files. Using the caching framework etc. means you don't need to do this by yourself anymore.

If you need further help, feel free to contact me.

Hope this helps!
benni.
