### PR TITLE
[FEATURE] add disableWizard-contentConfiguration

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -211,6 +211,9 @@ class Tx_Fluidcontent_Service_ConfigurationService extends Tx_Flux_Service_FluxS
 						$this->sendDisabledContentWarning($templateFilename);
 						continue;
 					}
+					if($contentConfiguration['disableWizard'] === 'TRUE') {
+						continue; 	
+					}
 					if (isset($contentConfiguration['wizardTab'])) {
 						$tabId = $this->sanitizeString($contentConfiguration['wizardTab']);
 						$wizardTabs[$tabId]['title'] = $contentConfiguration['wizardTab'];


### PR DESCRIPTION
adds a possibility to completely disable autoregistering a wizardTab for a FCE registered with the flux:flexform view helper

issue https://github.com/FluidTYPO3/fluidcontent/issues/115
