### PR TITLE
[WIP!!!][BUGFIX] Constant FLUIDCONTENT_TEMPFILE is not always defined

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -24,6 +24,7 @@ namespace FluidTYPO3\Fluidcontent\Service;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use FluidTYPO3\Fluidcontent\Utility\CacheFileUtility;
 use FluidTYPO3\Flux\Core;
 use FluidTYPO3\Flux\Service\FluxService;
 use FluidTYPO3\Flux\Utility\PathUtility;
@@ -106,7 +107,7 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 	 * @return NULL
 	 */
 	public function writeCachedConfigurationIfMissing() {
-		if (TRUE === file_exists(FLUIDCONTENT_TEMPFILE)) {
+		if (TRUE === CacheFileUtility::getInstance()->exists()) {
 			return;
 		}
 		$templates = $this->getAllRootTypoScriptTemplates();

--- a/Classes/Utility/CacheFileUtility.php
+++ b/Classes/Utility/CacheFileUtility.php
@@ -1,0 +1,88 @@
+<?php
+namespace FluidTYPO3\Fluidcontent\Utility;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Fabien Udriot <fabien.udriot@ecodev.ch>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Caching file utility
+ *
+ * Provides Utility method for managing the caching file.
+ *
+ * @author Fabien Udriot
+ * @package Fluidcontent
+ * @subpackage Utility
+ */
+class CacheFileUtility implements SingletonInterface {
+
+	/**
+	 * @var string
+	 */
+	protected $fileNameAndPath;
+
+	/**
+	 * Returns a class instance.
+	 *
+	 * @return CacheFileUtility
+	 */
+	static public function getInstance() {
+		return GeneralUtility::makeInstance('FluidTYPO3\Fluidcontent\Utility\CacheFileUtility');
+	}
+
+	/**
+	 * Tell whether the caching file exist or not.
+	 *
+	 * @return boolean
+	 */
+	public function exists(){
+		return file_exists($this->getFileNameAndPath());
+	}
+
+	/**
+	 * Return the file name and path of the caching file.
+	 *
+	 * @return string
+	 */
+	public function getFileNameAndPath() {
+		if (TRUE === is_null($this->fileNameAndPath)) {
+			$this->fileNameAndPath = GeneralUtility::getFileAbsFileName('typo3temp/.FED_CONTENT');
+		}
+		return $this->fileNameAndPath;
+	}
+
+	/**
+	 * Return the content of the caching file.
+	 *
+	 * @return string
+	 */
+	public function getContent() {
+		$result = '';
+		if ($this->exists()) {
+			$result = file_get_contents($this->getFileNameAndPath());
+		}
+		return $result;
+	}
+
+}

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,12 +3,9 @@ if (!defined ('TYPO3_MODE')) {
 	die ('Access denied.');
 }
 
-define('FLUIDCONTENT_TEMPFILE', \TYPO3\CMS\Core\Utility\GeneralUtility::getFileAbsFileName('typo3temp/.FED_CONTENT'));
-
 \FluidTYPO3\Flux\Core::unregisterConfigurationProvider('Tx_Fed_Provider_Configuration_ContentObjectConfigurationProvider');
 \FluidTYPO3\Flux\Core::registerConfigurationProvider('FluidTYPO3\Fluidcontent\Provider\ContentProvider');
 
-\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA('tt_content');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array('Fluid Content', 'fluidcontent_content', \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('fluidcontent') . 'ext_icon.gif'), 'CType');
 //\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Fluid Content'); // Disabled temporarily: fluidcontent currently does not use TS configuration.
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', array(
@@ -29,6 +26,6 @@ $GLOBALS['TCA']['tt_content']['types']['fluidcontent_content']['showitem'] = str
 $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['fluidcontent_content'] = 'apps-pagetree-root';
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_content', 'tx_fed_fcefile,pi_flexform', 'fluidcontent_content', 'after:header');
 
-if (file_exists(FLUIDCONTENT_TEMPFILE)) {
-	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(file_get_contents(FLUIDCONTENT_TEMPFILE));
+if (\FluidTYPO3\Fluidcontent\Utility\CacheFileUtility::getInstance()->exists()) {
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(\FluidTYPO3\Fluidcontent\Utility\CacheFileUtility::getInstance()->getContent());
 }


### PR DESCRIPTION
Constant FLUIDCONTENT_TEMPFILE is defined in ext_tables.php which is meant to
point to a file to cache Page TSConfig.

However, this leads to a problem as of TYPO3 6.1 which has a refactored 
caching mechanism. After the global TYPO3 cache has been set (processing of
ext_tables.php and ext_localconf.php among other), the constants is never
defined anymore. As a result Fluid Content is not able to cache Page TSConfig
anymore impacting the overall performance.
