### PR TITLE
made deprecated call to loadTCA conditional

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -9,7 +9,10 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['fluidcontent']['setup'] = unserialize($_
 Tx_Flux_Core::unregisterConfigurationProvider('Tx_Fed_Provider_Configuration_ContentObjectConfigurationProvider');
 Tx_Flux_Core::registerConfigurationProvider('Tx_Fluidcontent_Provider_ContentConfigurationProvider');
 
-t3lib_div::loadTCA('tt_content');
+
+if (version_compare(TYPO3_branch, '6.1', '<')) {
+	t3lib_div::loadTCA('tt_content');
+}
 t3lib_extMgm::addPlugin(array('Fluid Content', 'fluidcontent_content', t3lib_extMgm::extRelPath('fluidcontent') . 'ext_icon.gif'), 'CType');
 //t3lib_extMgm::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Fluid Content'); // Disabled temporarily: fluidcontent currently does not use TS configuration.
 t3lib_extMgm::addTCAcolumns('tt_content', array(


### PR DESCRIPTION
Calls to loadTCA are no longer necessary and bloats the deprecation-log quite fast...
http://docs.typo3.org/TYPO3/CoreApiReference/singlehtml/#id3

Fix copied from current version of realurl
