### PR TITLE
[BUGFIX] WorkspacesAwareRecordService is instanciated with wrong namespace

### DIFF
--- a/Classes/Hooks/WizardItemsHookSubscriber.php
+++ b/Classes/Hooks/WizardItemsHookSubscriber.php
@@ -85,7 +85,7 @@ class WizardItemsHookSubscriber implements NewContentElementWizardHookInterface 
 		$this->injectObjectManager($objectManager);
 		$configurationService = $this->objectManager->get('FluidTYPO3\Fluidcontent\Service\ConfigurationService');
 		$this->injectConfigurationService($configurationService);
-		$recordService = $this->objectManager->get('FluidTYPO3\Fluidcontent\Service\WorkspacesAwareRecordService');
+		$recordService = $this->objectManager->get('FluidTYPO3\Flux\Service\WorkspacesAwareRecordService');
 		$this->injectRecordService($recordService);
 	}
 


### PR DESCRIPTION
As long as WorkspacesAwareRecordService is located in flux and not in fluidcontent, this will cause an exception in the contentn element wizard.

Cheers Daniel.
