### PR TITLE
[TASK] Add runtime exception if fce doesnt have a controller action

### DIFF
--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -169,6 +169,9 @@ class ContentProvider extends FluxContentProvider implements ProviderInterface {
 	 */
 	public function getControllerActionFromRecord(array $row) {
 		$fileReference = $this->getControllerActionReferenceFromRecord($row);
+		if (TRUE === empty($fileReference)) {
+			throw new \RuntimeException('No content template found', 1404736585);
+		}
 		$identifier = explode(':', $fileReference);
 		$actionName = array_pop($identifier);
 		$actionName = basename($actionName, '.html');


### PR DESCRIPTION
If we dont throw this and fce doesnt have a controller action `TYPO3\CMS\Extbase\Mvc\Request::setControllerActionName` will throw one for us. This way exception is meaningful.
