### PR TITLE
Revert "[TASK] Add runtime exception if fce doesnt have a controller act...

### DIFF
--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -169,9 +169,6 @@ class ContentProvider extends FluxContentProvider implements ProviderInterface {
 	 */
 	public function getControllerActionFromRecord(array $row) {
 		$fileReference = $this->getControllerActionReferenceFromRecord($row);
-		if (TRUE === empty($fileReference)) {
-			throw new \RuntimeException('No content template found', 1404736585);
-		}
 		$identifier = explode(':', $fileReference);
 		$actionName = array_pop($identifier);
 		$actionName = basename($actionName, '.html');


### PR DESCRIPTION
Reverts FluidTYPO3/fluidcontent#173

Reason: throwing of exception in getter method. This method must be safe to execute, always. If no reference exists, `render` can be returned instead.
