### PR TITLE
[BUGFIX] WizardItemsHookSubscriber: column areas removed

### DIFF
--- a/Classes/Hooks/WizardItemsHookSubscriber.php
+++ b/Classes/Hooks/WizardItemsHookSubscriber.php
@@ -155,10 +155,8 @@ class WizardItemsHookSubscriber implements NewContentElementWizardHookInterface 
 				}
 				foreach ($grid->getRows() as $row) {
 					foreach ($row->getColumns() as $column) {
-						foreach ($column->getAreas() as $area) {
-							if ($area->getName() === $fluxAreaName) {
-								list ($whitelist, $blacklist) = $this->appendToWhiteAndBlacklistFromComponent($area, $whitelist, $blacklist);
-							}
+						if ($column->getName() === $fluxAreaName) {
+							list ($whitelist, $blacklist) = $this->appendToWhiteAndBlacklistFromComponent($column, $whitelist, $blacklist);
 						}
 					}
 				}


### PR DESCRIPTION
see: https://github.com/FluidTYPO3/flux/pull/613
