### PR TITLE
[FEATURE] Clear caches with the clearCache=system

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -18,5 +18,7 @@ if (!defined ('TYPO3_MODE')) {
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms']['db_new_content_el']['wizardItemsHook']['fluidcontent'] = 'FluidTYPO3\Fluidcontent\Hooks\WizardItemsHookSubscriber';
 
 if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['fluidcontent'])) {
-	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['fluidcontent'] = array();
+	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['fluidcontent'] = array(
+		'groups' => array('system')
+	);
 }


### PR DESCRIPTION
This commit adds the fluidcontent cache to the cache group 'system'.
This means, that the cache will be cleared when you use the
"Flush system caches" command.
Currently you need to go into the installer to clear this cache,
which gets tedious over time.
