### PR TITLE
[TASK] Switch to new Flux TemplatePaths/ViewContext objects

### DIFF
--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -14,6 +14,7 @@ use FluidTYPO3\Flux\Provider\ProviderInterface;
 use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 use FluidTYPO3\Flux\Utility\PathUtility;
 use FluidTYPO3\Flux\Utility\ResolveUtility;
+use FluidTYPO3\Flux\View\TemplatePaths;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
@@ -100,7 +101,8 @@ class ContentProvider extends FluxContentProvider implements ProviderInterface {
 		list (, $filename) = explode(':', $templatePathAndFilename);
 		list ($controllerAction, $format) = explode('.', $filename);
 		$paths = $this->getTemplatePaths($row);
-		$templatePathAndFilename = ResolveUtility::resolveTemplatePathAndFilenameByPathAndControllerNameAndActionAndFormat($paths, 'Content', $controllerAction, $format);
+		$templatePaths = new TemplatePaths($paths);
+		$templatePathAndFilename = $templatePaths->resolveTemplateFileForControllerAndActionAndFormat('Content', $controllerAction, $format);
 		return $templatePathAndFilename;
 	}
 

--- a/Tests/Unit/Provider/ContentProviderTest.php
+++ b/Tests/Unit/Provider/ContentProviderTest.php
@@ -64,7 +64,7 @@ class ContentProviderTest extends UnitTestCase {
 	public function getTemplatePathAndFilenameTestValues() {
 		return array(
 			array(array('uid' => 0), NULL),
-			array(array('tx_fed_fcefile' => 'test:test'), NULL),
+			array(array('tx_fed_fcefile' => 'test:Test.html'), NULL),
 		);
 	}
 


### PR DESCRIPTION
This change makes Fluidcontent's classes utilise the new components of Flux which hold a view context and template path collections.

Depends: https://github.com/FluidTYPO3/flux/pull/758