### PR TITLE
[DOC] Fix documentation link badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Fluidcontent: Fluid Content Elements
 ====================================
 
-[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.fluidtypo3.org/fluidcontent.svg?style=flat-square)](https://jenkins.fluidtypo3.org/job/fluidcontent) [![Coverage Status](https://img.shields.io/coveralls/FluidTYPO3/fluidcontent/development.svg?style=flat-square)](https://coveralls.io/r/FluidTYPO3/fluidcontent) [![Build status](http://img.shields.io/badge/documentation-online-blue.svg?style=flat-square)](https://fluidtypo3.org/templating-manual/introduction.html)
+[![Build Status](https://img.shields.io/jenkins/s/https/jenkins.fluidtypo3.org/fluidcontent.svg?style=flat-square)](https://jenkins.fluidtypo3.org/job/fluidcontent) [![Coverage Status](https://img.shields.io/coveralls/FluidTYPO3/fluidcontent/development.svg?style=flat-square)](https://coveralls.io/r/FluidTYPO3/fluidcontent) [![Build status](http://img.shields.io/badge/documentation-online-blue.svg?style=flat-square)](https://fluidtypo3.org/documentation/templating-manual/introduction.html)
 
 ## What does it do?
 


### PR DESCRIPTION
Documentation link badge in ``README.md`` points to a non existing page.