### PR TITLE
[TASK] Get rid of deprecation log

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -20,7 +20,7 @@ if (!defined ('TYPO3_MODE')) {
 			'userFunc' => 'FluidTYPO3\Fluidcontent\Backend\ContentSelector->renderField',
 		)
 	),
-), 1);
+));
 
 $GLOBALS['TCA']['tt_content']['types']['fluidcontent_content']['showitem'] = $GLOBALS['TCA']['tt_content']['types']['text']['showitem'];
 // Remove bodytext RTE with TCA pointing to locallang file in xlf format


### PR DESCRIPTION
Deprecated method. I don't want the message => `Usage of feInterface is
no longer part of the TYPO3 CMS Core` anymore ;-) ... and since core min. is 6.2 that's no problem.