### PR TITLE
[BUGFIX] Fix $optionValue declaration

### DIFF
--- a/Classes/Backend/ContentSelector.php
+++ b/Classes/Backend/ContentSelector.php
@@ -92,8 +92,8 @@ class ContentSelector {
 	protected function renderOptionGroup(array $configuration, $groupLabel, $value) {
 		foreach ($configuration as $form) {
 			/** @var Form $form */
-			$selected = ($optionValue === $value ? ' selected="selected"' : '');
 			$optionValue = $form->getOption('contentElementId');
+			$selected = ($optionValue === $value ? ' selected="selected"' : '');
 			$label = $form->getLabel();
 			$icon = MiscellaneousUtility::getIconForTemplate($form);
 			$label = (0 === strpos($label, 'LLL:') ? $GLOBALS['LANG']->sL($label) : $label);


### PR DESCRIPTION
$optionValue must be declared before comparing, otherwise the select box value changes every time the form is saved. This happens under TYPO3 6.2.