### PR TITLE
[BUGFIX] Use the native PHP "lcfirst" function to lowercase the first character.

### DIFF
--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -152,8 +152,7 @@ class ContentProvider extends FluxContentProvider implements ProviderInterface {
 		$fileReference = $this->getControllerActionReferenceFromRecord($row);
 		$identifier = explode(':', $fileReference);
 		$actionName = array_pop($identifier);
-		$actionName = basename($actionName, '.html');
-		$actionName{0} = strtolower($actionName{0});
+		$actionName = lcfirst(basename($actionName, '.html'));
 		return $actionName;
 	}
 


### PR DESCRIPTION
The current string char access method ("$actionName{0}") can return an array if the $actionName is an empty string!