### PR TITLE
[TASK] Add trailing slash to getAllFilesAndFoldersInPath path

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -242,7 +242,7 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 			$viewContext->setTemplatePaths($templatePaths);
 			$viewContext->setSectionName('Configuration');
 			foreach ($templatePaths->getTemplateRootPaths() as $templateRootPath) {
-				$files = GeneralUtility::getAllFilesAndFoldersInPath($files, $templateRootPath . '/' . $controllerName, 'html');
+				$files = GeneralUtility::getAllFilesAndFoldersInPath($files, $templateRootPath . '/' . $controllerName .'/', 'html');
 				if (0 < count($files)) {
 					foreach ($files as $templateFilename) {
 						$actionName = pathinfo($templateFilename, PATHINFO_FILENAME);


### PR DESCRIPTION
Fix
https://github.com/FluidTYPO3/fluidcontent/issues/248
https://github.com/FluidTYPO3/fluidcontent/issues/227

Core code needs trailing slash:
```php
	static public function getAllFilesAndFoldersInPath(array $fileArr, $path, $extList = '', $regDirs = FALSE, $recursivityLevels = 99, $excludePattern = '') {
		if ($regDirs) {
			$fileArr[md5($path)] = $path;
		}
		$fileArr = array_merge($fileArr, self::getFilesInDir($path, $extList, 1, 1, $excludePattern));
		$dirs = self::get_dirs($path);
		if ($recursivityLevels > 0 && is_array($dirs)) {
			foreach ($dirs as $subdirs) {
				if ((string)$subdirs !== '' && ($excludePattern === '' || !preg_match(('/^' . $excludePattern . '$/'), $subdirs))) {
					$fileArr = self::getAllFilesAndFoldersInPath($fileArr, $path . $subdirs . '/', $extList, $regDirs, $recursivityLevels - 1, $excludePattern);
				}
			}
		}
		return $fileArr;
	}
```
$path . $subdirs . '/' - missing slash after path