### PR TITLE
[BUGFIX] Show only the preview if CType is equal to 'fluidcontent_con…

### DIFF
--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -181,7 +181,7 @@ class ContentProvider extends FluxContentProvider implements ProviderInterface {
 	 */
 	public function getControllerActionReferenceFromRecord(array $row) {
 		$fileReference = $row['tx_fed_fcefile'];
-		return TRUE === empty($fileReference) ? 'Fluidcontent:index.html' : $fileReference;
+		return TRUE === empty($fileReference) ? 'Fluidcontent:error.html' : $fileReference;
 	}
 
 	/**
@@ -196,6 +196,23 @@ class ContentProvider extends FluxContentProvider implements ProviderInterface {
 			return 100;
 		}
 		return 0;
+	}
+
+	/**
+	 * Get preview chunks - header and content - as
+	 * array(string $headerContent, string $previewContent, boolean $continueRendering)
+	 *
+	 * @param array $row The record data to be analysed for variables to use in a rendered preview
+	 * @return array
+	 */
+	public function getPreview(array $row) {
+
+		if ($this->contentObjectType !== $row['CType']) {
+			return array(NULL, NULL, TRUE);
+		}
+
+		$previewContent = $this->getPreviewView()->getPreview($this, $row);
+		return array(NULL, $previewContent, empty($previewContent));
 	}
 
 }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -30,6 +30,9 @@
 			<trans-unit id="tt_content.tx_fed_fcefile.emptyMessage">
 				<source>Fluid Content type not selected - edit this element in the TYPO3 backend to fix this!</source>
 			</trans-unit>
+			<trans-unit id="tt_content.tx_fed_fcefile.emptyMessageinBackend">
+				<source>Fluid Content type not selected - edit this element to fix this!</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Templates/Content/Error.html
+++ b/Resources/Private/Templates/Content/Error.html
@@ -1,0 +1,56 @@
+{namespace flux=FluidTYPO3\Flux\ViewHelpers}
+<f:layout name="Content"/>
+<f:section name="Configuration">
+	<flux:form id="error">
+		<flux:field.custom name="info">
+
+			<div class="alert alert-warning">
+				<div class="media">
+					<div class="media-left">
+						<span class="fa-stack fa-lg">
+							<i class="fa fa-circle fa-stack-2x"></i>
+							<i class="fa fa-exclamation fa-stack-1x"></i>
+						</span>
+					</div>
+					<div class="media-body">
+						<h4 class="alert-title">Warning</h4>
+
+						<div class="alert-message">
+							<f:translate key="tt_content.tx_fed_fcefile.emptyMessageinBackend"/>
+						</div>
+					</div>
+				</div>
+			</div>
+
+		</flux:field.custom>
+	</flux:form>
+</f:section>
+
+<f:section name="Preview">
+
+	<div class="alert alert-warning">
+		<div class="media">
+			<div class="media-left">
+						<span class="fa-stack fa-lg">
+							<i class="fa fa-circle fa-stack-2x"></i>
+							<i class="fa fa-exclamation fa-stack-1x"></i>
+						</span>
+			</div>
+			<div class="media-body">
+				<h4 class="alert-title">Warning</h4>
+
+				<div class="alert-message">
+					<f:translate key="tt_content.tx_fed_fcefile.emptyMessageinBackend"/>
+				</div>
+			</div>
+		</div>
+	</div>
+
+</f:section>
+
+<f:section name="Main">
+	<div style="background:#ff0; color:#000; padding: 20px; margin:20px;">
+		<f:translate key="tt_content.tx_fed_fcefile.emptyMessage"/>
+		<br> <br> Content uid: [{record.uid}]
+	</div>
+</f:section>

--- a/Tests/Unit/Provider/ContentProviderTest.php
+++ b/Tests/Unit/Provider/ContentProviderTest.php
@@ -65,7 +65,7 @@ class ContentProviderTest extends UnitTestCase {
 		$path = ExtensionManagementUtility::extPath('fluidcontent');
 		$file = $path . 'Resources/Private/Templates/Content/Error.html';
 		return array(
-			array(array('uid' => 0), NULL),
+			array(array('uid' => 0), $file),
 			array(array('tx_fed_fcefile' => 'test:Error.html'), NULL),
 			array(array('tx_fed_fcefile' => 'fluidcontent:Error.html'), $file),
 		);
@@ -141,7 +141,7 @@ class ContentProviderTest extends UnitTestCase {
 	 */
 	public function getControllerActionFromRecordTestValues() {
 		return array(
-			array(array('uid' => 0), 'index'),
+			array(array('uid' => 0), 'error'),
 			array(array('tx_fed_fcefile' => 'test:test'), 'test'),
 		);
 	}


### PR DESCRIPTION
…tent'

 Avoid rendering of the preview if the field 'tx_fed_fcefile' isn't empty,
 and also CType isn't equal to 'fluidcontent_content'.
 This happens, if you change the CType of an 'fluidcontent_content' element.

 If the CType is equal to 'fluidcontent_content' and the field 'tx_fed_fcefile' is empty,
 then a warning message is showing:
 * when you edit the 'fluidcontent_content' element
 * in the backend on the page module
 * in the frontend view.

 The template Content/Error.html is used for showing the messages.

![backend-edit](https://cloud.githubusercontent.com/assets/1583746/9816435/4d4b7826-589d-11e5-9917-3751a4598faa.png)

![backend-web](https://cloud.githubusercontent.com/assets/1583746/9816437/531a68d4-589d-11e5-9eb3-47ce5189df29.png)

![frontend](https://cloud.githubusercontent.com/assets/1583746/9816441/584babd8-589d-11e5-9659-3e88b82f8fc9.png)
