### PR TITLE
[BUGFIX] New content element wizard shows no icons in TYPO3 7.5

### DIFF
--- a/Classes/Service/LegacyWizardTabService.php
+++ b/Classes/Service/LegacyWizardTabService.php
@@ -1,0 +1,74 @@
+<?php
+namespace FluidTYPO3\Fluidcontent\Service;
+
+/*
+ * This file is part of the FluidTYPO3/Fluidcontent project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\Utility\MiscellaneousUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * WizardTab Service for TYPO3 Version < 7.5
+ *
+ * Provides methods to create a WizardTab item
+ */
+class LegacyWizardTabService extends WizardTabService {
+
+   /**
+    * Builds a single Wizard item (one FCE) based on the
+    * tab id, element id, configuration array and special
+    * template identity (groupName:Relative/Path/File.html)
+    *
+    * @param ConfigurationService $configurationService
+    * @param string               $tabId
+    * @param string               $id
+    * @param Form                 $form
+    * @param string               $templateFileIdentity
+    *
+    * @return string
+    */
+   public function buildWizardTabItem($configurationService, $tabId, $id, $form, $templateFileIdentity) {
+      if (TRUE === method_exists('FluidTYPO3\\Flux\\Utility\\MiscellaneousUtility', 'getIconForTemplate')) {
+         $icon = MiscellaneousUtility::getIconForTemplate($form);
+         $icon = ($icon ? $icon : $configurationService->getDefaultIcon());
+      } else {
+         $icon = $configurationService->getDefaultIcon();
+      }
+      $description = $form->getDescription();
+      if (0 === strpos($icon, '../')) {
+         $icon = substr($icon, 2);
+      }
+
+      if (TRUE === file_exists($icon) && TRUE === method_exists('FluidTYPO3\\Flux\\Utility\\MiscellaneousUtility', 'createIcon')) {
+         if ('/' === $icon[0]) {
+            $icon = realpath(PATH_site . $icon);
+         }
+         $extConf = $configurationService->getExtConf();
+         $icon = '../..' . MiscellaneousUtility::createIcon($icon, $extConf['iconWidth'], $extConf['iconHeight']);
+      }
+
+      return sprintf('
+			mod.wizards.newContentElement.wizardItems.%s.elements.%s {
+				icon = %s
+				title = %s
+				description = %s
+				tt_content_defValues {
+					CType = fluidcontent_content
+					tx_fed_fcefile = %s
+				}
+			}
+			',
+         $tabId,
+         $id,
+         $icon,
+         $form->getLabel(),
+         $description,
+         $templateFileIdentity
+      );
+   }
+}

--- a/Classes/Service/WizardTabService.php
+++ b/Classes/Service/WizardTabService.php
@@ -1,0 +1,86 @@
+<?php
+namespace FluidTYPO3\Fluidcontent\Service;
+
+/*
+ * This file is part of the FluidTYPO3/Fluidcontent project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\Utility\MiscellaneousUtility;
+use TYPO3\CMS\Core\Imaging\IconRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * WizardTab Service
+ *
+ * Provides methods to create a WizardTab item
+ * Using TYPO3\CMS\Core\Imaging\IconRegistry to register the icon
+ */
+class WizardTabService {
+
+   /**
+    * Builds a single Wizard item (one FCE) based on the
+    * tab id, element id, configuration array and special
+    * template identity (groupName:Relative/Path/File.html)
+    *
+    * @param ConfigurationService $configurationService
+    * @param string               $tabId
+    * @param string               $id
+    * @param Form                 $form
+    * @param string               $templateFileIdentity
+    *
+    * @return string
+    */
+   public function buildWizardTabItem($configurationService, $tabId, $id, $form, $templateFileIdentity) {
+      $iconRegistry = GeneralUtility::makeInstance(IconRegistry::class);
+
+      if (TRUE === method_exists(MiscellaneousUtility::class, 'getIconForTemplate')) {
+         $icon = MiscellaneousUtility::getIconForTemplate($form);
+         $icon = ($icon ? $icon : $configurationService->getDefaultIcon());
+      } else {
+         $icon = $configurationService->getDefaultIcon();
+      }
+      $description = $form->getDescription();
+      if (0 === strpos($icon, '../')) {
+         $icon = substr($icon, 2);
+      }
+      if ('/' === $icon[0]) {
+         $icon = realpath(PATH_site . $icon);
+      }
+
+      if (TRUE === file_exists($icon) && TRUE === method_exists(MiscellaneousUtility::class, 'createIcon')) {
+         $ext = strtolower(pathinfo($icon, PATHINFO_EXTENSION));
+
+         $iconRegistry->registerIcon(
+            'content-' . $id,
+            $ext === 'svg' ? \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class : \TYPO3\CMS\Core\Imaging\IconProvider\BitmapIconProvider::class,
+            array(
+               'source' => $icon
+            )
+         );
+      }
+
+      return sprintf('
+			mod.wizards.newContentElement.wizardItems.%s.elements.%s {
+				iconIdentifier = %s
+				title = %s
+				description = %s
+				tt_content_defValues {
+					CType = fluidcontent_content
+					tx_fed_fcefile = %s
+				}
+			}
+			',
+         $tabId,
+         $id,
+         'content-' . $id,
+         $form->getLabel(),
+         $description,
+         $templateFileIdentity
+      );
+   }
+
+}

--- a/Tests/Unit/Service/ConfigurationServiceTest.php
+++ b/Tests/Unit/Service/ConfigurationServiceTest.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 class ConfigurationServiceTest extends UnitTestCase {
 
 	public function testGetContentConfiguration() {
+
 		Core::registerProviderExtensionKey('FluidTYPO3.Fluidcontent', 'Content');
 		/** @var ConfigurationService $service */
 		$service = $this->getMock('FluidTYPO3\\Fluidcontent\\Service\\ConfigurationService', array('dummy'), array(), '', FALSE);
@@ -99,8 +100,9 @@ class ConfigurationServiceTest extends UnitTestCase {
 		$form = Form::create();
 		$form->setLabel('bazlabel');
 		$form->setDescription('foobar');
+		$wizardTabService = GeneralUtility::makeInstance('FluidTYPO3\\Fluidcontent\\Service\\LegacyWizardTabService');
 		$service = $this->getMock('FluidTYPO3\\Fluidcontent\\Service\\ConfigurationService', array(), array(), '', FALSE);
-		$result = $this->callInaccessibleMethod($service, 'buildWizardTabItem', 'tabid', 'id', $form, '');
+		$result = $this->callInaccessibleMethod($wizardTabService, 'buildWizardTabItem', $service, 'tabid', 'id', $form, '');
 		$this->assertContains('tabid.elements.id', $result);
 		$this->assertContains('title = bazlabel', $result);
 		$this->assertContains('description = foobar', $result);
@@ -151,6 +153,14 @@ class ConfigurationServiceTest extends UnitTestCase {
 	 * @return void
 	 */
 	public function testBuildAllWizardTabGroups() {
+		\FluidTYPO3\Flux\Utility\CompatibilityRegistry::register(
+			'FluidTYPO3\\Fluidcontent\\Service\\WizardTabService',
+			array(
+				'6.2.0' => 'FluidTYPO3\\Fluidcontent\\Service\\LegacyWizardTabService',
+				'7.5.0' => 'FluidTYPO3\\Fluidcontent\\Service\\WizardTabService'
+			)
+		);
+
 		$class = substr(str_replace('Tests\\Unit\\', '', get_class($this)), 0, -4);
 		/** @var ConfigurationService|\PHPUnit_Framework_MockObject_MockObject $mock */
 		$mock = $this->getMock($class, array('getContentConfiguration', 'message'));

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -16,6 +16,14 @@ if (!defined ('TYPO3_MODE')) {
 
 \FluidTYPO3\Flux\Core::registerConfigurationProvider('FluidTYPO3\Fluidcontent\Provider\ContentProvider');
 
+\FluidTYPO3\Flux\Utility\CompatibilityRegistry::register(
+	'FluidTYPO3\\Fluidcontent\\Service\\WizardTabService',
+	array(
+		'6.2.0' => 'FluidTYPO3\\Fluidcontent\\Service\\LegacyWizardTabService',
+		'7.5.0' => 'FluidTYPO3\\Fluidcontent\\Service\\WizardTabService'
+	)
+);
+
 if ('BE' === TYPO3_MODE) {
 	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms']['db_new_content_el']['wizardItemsHook']['fluidcontent'] = 'FluidTYPO3\Fluidcontent\Hooks\WizardItemsHookSubscriber';
 	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['extTablesInclusion-PostProcessing']['fluidcontent'] = 'FluidTYPO3\Fluidcontent\Backend\TableConfigurationPostProcessor';


### PR DESCRIPTION
Using a separate class to build the wizard tab item icon with TYPO3\CMS\Core\Imaging\IconRegistry.
 This class has a legacy version for TYPO3 < 7.5.