### PR TITLE
[BUGFIX] Check file_exists after realpath

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -345,11 +345,13 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 			$icon = substr($icon, 2);
 		}
 
-		if (TRUE === file_exists($icon) && TRUE === method_exists('FluidTYPO3\\Flux\\Utility\\MiscellaneousUtility', 'createIcon')) {
+		if (TRUE === method_exists('FluidTYPO3\\Flux\\Utility\\MiscellaneousUtility', 'createIcon')) {
 			if ('/' === $icon[0]) {
 				$icon = realpath(PATH_site . $icon);
 			}
-			$icon = '../..' . MiscellaneousUtility::createIcon($icon, $this->extConf['iconWidth'], $this->extConf['iconHeight']);
+			if (TRUE === file_exists($icon)) {
+				$icon = '../..' . MiscellaneousUtility::createIcon($icon, $this->extConf['iconWidth'], $this->extConf['iconHeight']);
+			}
 		}
 
 		return sprintf('


### PR DESCRIPTION
I had the some issues with the icons in the wizard tabs, so I checked trough the code.
I found out that the existence of the file is checked before the real path is generated.
So I moved the "file_exists if" inside the Flux Method detection if.

This should also fix https://github.com/FluidTYPO3/fluidcontent/issues/281