### PR TITLE
[FEATURE] Extend Wizard groups instead of replacing

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Core\Cache\Frontend\StringFrontend;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Configuration Service
@@ -239,7 +240,14 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 					$group = 'Content';
 				}
 				$tabId = $this->sanitizeString($group);
-				$wizardTabs[$tabId]['title'] = $group;
+				$wizardTabs[$tabId]['title'] = LocalizationUtility::translate('fluidcontent.newContentWizard.group.' . $group, ExtensionNamingUtility::getExtensionKey($extensionKey));
+				if ($wizardTabs[$tabId]['title'] === NULL) {
+					$coreTranslationReference = 'LLL:EXT:backend/Resources/Private/Language/locallang_db_new_content_el.xlf:' . $group;
+					$wizardTabs[$tabId]['title'] = LocalizationUtility::translate($coreTranslationReference, 'backend');
+					if ($coreTranslationReference == $wizardTabs[$tabId]['title']) {
+						$wizardTabs[$tabId]['title'] = $group;
+					}
+				}
 				$contentElementId = $form->getOption('contentElementId');
 				$elementTsConfig = $this->buildWizardTabItem($tabId, $id, $form, $contentElementId);
 				$wizardTabs[$tabId]['elements'][$id] = $elementTsConfig;
@@ -308,7 +316,7 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 			$pageTsConfig .= sprintf('
 				mod.wizards.newContentElement.wizardItems.%s {
 					header = %s
-					show = %s
+					show := addToList(%s)
 					position = 0
 					key = %s
 				}


### PR DESCRIPTION
So far, if you tried to put fluidcontent elements into an existing new content wizard group like
"common", "special", etc it simply replaced all existing content elements and the title as well.
This commit changes that behavior to extend existing groups instead, use the default core
group translation, or use a localized translation for the group name.

**Example**

This example puts a new content element inside the core wizard group "common", by default the
regular title from TYPO3 core will be used to render the Tab title

```html
<flux:form id="example" options="{group: 'common'}">...</flux:form>
```

**Translation** ```(Language/Locallang.xlf)```

If you specify a translation like this for your tab title that will be used instead

```html
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<xliff version="1.0">
	<file source-language="en" datatype="plaintext" original="messages" product-name="template" date="2015-11-05T17:15:22+01:00">
		<header/>
		<body>
			<trans-unit id="fluidcontent.newContentWizard.group.common">
				<source>MY FANCY CONTENT!!asdasd!</source>
			</trans-unit>
		</body>
	</file>
</xliff>

```