### PR TITLE
[TASK] CType shortcut, render preview of original fluidcontent CE

### DIFF
--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -15,6 +15,7 @@ use FluidTYPO3\Flux\Provider\ProviderInterface;
 use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 use FluidTYPO3\Flux\Utility\PathUtility;
 use FluidTYPO3\Flux\View\TemplatePaths;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
@@ -206,6 +207,12 @@ class ContentProvider extends FluxContentProvider implements ProviderInterface {
 	 * @return array
 	 */
 	public function getPreview(array $row) {
+
+		if ('shortcut' === $row['CType'] && FALSE === strpos($row['records'], ',')) {
+			$originalRecord = BackendUtility::getRecord('tt_content', $row['records']);
+			$previewContent = '<br />' . $this->getPreviewView()->getPreview($this, $originalRecord);
+			return array(NULL, $previewContent, empty($previewContent));
+		}
 
 		if ($this->contentObjectType !== $row['CType']) {
 			return array(NULL, NULL, TRUE);


### PR DESCRIPTION
If a shortcut record is created for a fluidcontent it contained no
preview.
The original problem mentioned in #289 is not longer present for
TYPO3 7.x.