### PR TITLE
[FEATURE] Add option to specify defValues

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -406,6 +406,12 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 				$iconRegistry->registerIcon($iconIdentifier, BitmapIconProvider::class, array('source' => $icon));
 			}
 		}
+		$defaultValues = array();
+		if ($form->hasOption(Form::OPTION_DEFAULT_VALUES)) {
+			foreach ($form->getOption(Form::OPTION_DEFAULT_VALUES) as $key => $value) {
+				$defaultValues[] = $key . ' = ' . $value;
+			}
+		}
 
 		return sprintf('
 			mod.wizards.newContentElement.wizardItems.%s.elements.%s {
@@ -413,6 +419,7 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 				title = %s
 				description = %s
 				tt_content_defValues {
+					%s
 					CType = fluidcontent_content
 					tx_fed_fcefile = %s
 				}
@@ -423,6 +430,7 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 			$iconIdentifier,
 			$form->getLabel(),
 			$description,
+			implode(chr(10), $defaultValues),
 			$templateFileIdentity
 		);
 	}


### PR DESCRIPTION
This adds default values based on a new option added to the flux form class. Handy to specify a specific layout, or other defValue for a specific content element.

**example**

```html
<flux:form id="foo" options="{defaultValues: {layout: 10}}" label="foo">
```

depends on: https://github.com/FluidTYPO3/flux/pull/1022