### PR TITLE
[BUGFIX] New content element wizard - tabs not created if translation…

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -286,7 +286,7 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 				if ($wizardTabs[$tabId]['title'] === NULL) {
 					$coreTranslationReference = 'LLL:EXT:backend/Resources/Private/Language/locallang_db_new_content_el.xlf:' . $group;
 					$wizardTabs[$tabId]['title'] = LocalizationUtility::translate($coreTranslationReference, 'backend');
-					if ($coreTranslationReference == $wizardTabs[$tabId]['title']) {
+					if ($wizardTabs[$tabId]['title'] === NULL || $coreTranslationReference == $wizardTabs[$tabId]['title']) {
 						$wizardTabs[$tabId]['title'] = $group;
 					}
 				}


### PR DESCRIPTION
… not found.

LocalizationUtillity::translate could also be NULL
The elements are displayed in the previous named tab.