### PR TITLE
[BUGFIX] Reload content edit form when changing fluid content type

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -20,6 +20,7 @@ $contentSelector = 'FluidTYPO3\Fluidcontent\Backend\ContentSelector->renderField
 	),
 ));
 
+$GLOBALS['TCA']['tt_content']['ctrl']['requestUpdate'] .= ',tx_fed_fcefile';
 $GLOBALS['TCA']['tt_content']['types']['fluidcontent_content']['showitem'] = '
                 --palette--;LLL:EXT:cms/locallang_ttc.xlf:palette.general;general,
                 --palette--;LLL:EXT:cms/locallang_ttc.xlf:palette.headers;headers,


### PR DESCRIPTION
When changing the fluid content type of an element, the form needs to
be reloaded to show the correct fields.
This is especially important for frontend editing - there is no
element pre-selected.