### PR TITLE
[BUGFIX] Use correct content element icon path

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -424,7 +424,7 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 		$iconIdentifier = NULL;
 		if (TRUE === method_exists('FluidTYPO3\\Flux\\Utility\\MiscellaneousUtility', 'createIcon')) {
 			if ('/' === $icon[0]) {
-				$icon = realpath(PATH_site . $icon);
+				$icon = PATH_site . ltrim($icon, '/');
 			}
 			if (TRUE === file_exists($icon) && TRUE === is_file($icon)) {
 				$extension = pathinfo($icon, PATHINFO_EXTENSION);


### PR DESCRIPTION
Icons in the new content element wizard are broken if
the TYPO3 root directory is a symlink.

realpath() was used to fix a double-slash issue in the icon path,
but this breaks PATH_site detection.
Instead of relying on realpath to fix it, we correctly remove the leading
slash now, keeping the original path.

Without the fix, your browser will try to load icons with their full disk path
like
http://localhost/var/www/site/typo3conf/ext/foo/Resources/Public/Icons/Content/Foo.svg

Might be related to FluidTYPO3/flux#943