### PR TITLE
[BUGFIX] don't resolve symlinks on icon discovery

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -425,7 +425,7 @@ class ConfigurationService extends FluxService implements SingletonInterface {
 		$iconIdentifier = NULL;
 		if (TRUE === method_exists('FluidTYPO3\\Flux\\Utility\\MiscellaneousUtility', 'createIcon')) {
 			if ('/' === $icon[0]) {
-				$icon = realpath(PATH_site . $icon);
+				$icon = rtrim(PATH_site, '/') . $icon;
 			}
 			if (TRUE === file_exists($icon) && TRUE === is_file($icon)) {
 				$extension = pathinfo($icon, PATHINFO_EXTENSION);


### PR DESCRIPTION
Avoid using realpath so symlinks in PATH_site are not transformed,
otherwise icons are inaccessible.

This should close #334 as well.