### PR TITLE
[FEATURE] Enable the use of EXT:extensionname/ paths for icons and

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,39 +1,44 @@
 <?php
 if (!defined('TYPO3_MODE')) {
-	die ('Access denied.');
+    die ('Access denied.');
 }
 
-$contentSelector = 'FluidTYPO3\Fluidcontent\Backend\ContentSelector->renderField';
+call_user_func(function () {
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', array(
-	'tx_fed_fcefile' => array(
-		'exclude' => 1,
-		'label' => 'LLL:EXT:fluidcontent/Resources/Private/Language/locallang.xml:tt_content.tx_fed_fcefile',
-		'displayCond' => 'FIELD:CType:=:fluidcontent_content',
-		'config' => array(
-			'type' => 'select',
-			'renderType' => 'selectSingle',
-			'items' => array(
-				array('LLL:EXT:fluidcontent/Resources/Private/Language/locallang.xml:tt_content.tx_fed_fcefile', '')
-			)
-		)
-	),
-));
+    $languageFilePrefix         = 'LLL:EXT:fluidcontent/Resources/Private/Language/locallang.xlf:';
+    $frontendLanguageFilePrefix = 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:';
 
-$GLOBALS['TCA']['tt_content']['ctrl']['requestUpdate'] .= ',tx_fed_fcefile';
-$GLOBALS['TCA']['tt_content']['types']['fluidcontent_content']['showitem'] = '
-                --palette--;LLL:EXT:cms/locallang_ttc.xlf:palette.general;general,
-                --palette--;LLL:EXT:cms/locallang_ttc.xlf:palette.headers;headers,
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', [
+       'tx_fed_fcefile' => [
+          'exclude'     => 1,
+          'label'       => $languageFilePrefix . 'tt_content.tx_fed_fcefile',
+          'displayCond' => 'FIELD:CType:=:fluidcontent_content',
+          'config'      => [
+             'type'          => 'select',
+             'renderType'    => 'selectSingle',
+             'items'         => [
+                [$languageFilePrefix . 'tt_content.tx_fed_fcefile', ''],
+             ],
+             'showIconTable' => false,
+             'selicon_cols'  => 0,
+          ],
+       ],
+    ]);
+
+    $GLOBALS['TCA']['tt_content']['ctrl']['requestUpdate'] .= ',tx_fed_fcefile';
+    $GLOBALS['TCA']['tt_content']['types']['fluidcontent_content']['showitem'] = '
+                --palette--;' . $frontendLanguageFilePrefix . 'palette.general;general,
+                --palette--;' . $frontendLanguageFilePrefix . 'palette.headers;headers,
                 pi_flexform,
-        --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.appearance,
-                --palette--;LLL:EXT:cms/locallang_ttc.xlf:palette.frames;frames,
-        --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access,
-                --palette--;LLL:EXT:cms/locallang_ttc.xlf:palette.visibility;visibility,
-                --palette--;LLL:EXT:cms/locallang_ttc.xlf:palette.access;access,
-        --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.extended
+        --div--;' . $frontendLanguageFilePrefix . 'tabs.appearance,
+                --palette--;' . $frontendLanguageFilePrefix . 'palette.frames;frames,
+        --div--;' . $frontendLanguageFilePrefix . 'tabs.access,
+				    hidden;' . $frontendLanguageFilePrefix . 'field.default.hidden,
+                --palette--' . $frontendLanguageFilePrefix . 'palette.access;access,
+        --div--;' . $frontendLanguageFilePrefix . 'tabs.extended
 ';
 
-$GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['fluidcontent_content'] = 'apps-pagetree-root';
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('tt_content', 'general', 'tx_fed_fcefile', 'after:CType');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_content', 'pi_flexform', 'fluidcontent_content', 'after:header');
-
+    $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['fluidcontent_content'] = 'apps-pagetree-root';
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('tt_content', 'general', 'tx_fed_fcefile', 'after:CType');
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_content', 'pi_flexform', 'fluidcontent_content', 'after:header');
+});

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -9,6 +9,6 @@ if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL)) {
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(array(
 		'Fluid Content',
 		'fluidcontent_content',
-		\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('fluidcontent') . 'ext_icon.gif'
+		'EXT:fluidcontent/Resources/Public/Icons/Plugin.svg'
 	), \TYPO3\CMS\Extbase\Utility\ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT, 'FluidTYPO3.Fluidcontent');
 }


### PR DESCRIPTION
other optimazings

with this PR the icons are displayed correct in the element backend forms ( fields: content element type and fluid content type ). if relative paths are defined in flux:form.option.icon then the icons are not shown

ConfigurationService.php
- Removed unused constants ICON_WIDTH and ICON_HEIGHT
- Enables ```EXT:extensioname``` icon paths definitions - ```<flux:form.option.icon>EXT:extensioname/Resources/Public/Icons/myicon.svg</flux:form.option.icon>```
- new feature in ```getContentTypeSelectorItems```: grouping the items at the name of the item wizard group ```<flux:form.option.group>Goupname</flux:form.option.group>``` - see changes in ext_conf_template.txt

ext:tables.php
 - The extension icon is defined with ```EXT:fluidcontent``` path - now the icon is showing correct in the backend form in field "content element type"

ext_conf_template.txt
- new configuration "useGroups" to prepare items of the "fluid content type" select box. If enabled, the output of the list is equivalent to the item wizard groups, the items are grouped by the name defined in flux:form.option.group. If disabled, the old behavior is used - output is grouped by the name of the fluidcontent extension.
- showIconTable - if enabled the icons from the fluidcontent elements are displayed below the select box
- showIconTableCols - set the number of icon columns

 tt_content.php
 - Removed unused ```$contentSelector```
 - Using a closure for preparing configuration
 - Extended field ```tx_fed_fcefile``` with 'showIconTable' and 'selicon_cols': see ext_conf_template.txt
 - Using vars for the different language files.

 info: for TYPO3 8.x the TCA configuration must be changed cause the names of the palettes have changed.