### PR TITLE
[BUGFIX] Missing check if 'tx_fed_fcefile' exists

### DIFF
--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -99,7 +99,7 @@ class ContentProvider extends FluxContentProvider implements ProviderInterface
      */
     public function processTableConfiguration(array $row, array $configuration)
     {
-        if ($row['CType'] === $this->contentObjectType) {
+        if ($row['CType'] === $this->contentObjectType && isset($configuration['processedTca']['columns']['tx_fed_fcefile'])) {
             // Create values for the fluidcontent type selector
             $configuration['processedTca']['columns']['tx_fed_fcefile']['config']['items'] = array_merge(
                 $configuration['processedTca']['columns']['tx_fed_fcefile']['config']['items'],


### PR DESCRIPTION
The SVGTree.js is calling 'proccessTableConfiguration' via Ajax and then the field 'tx_fed_fcefile' isn't present in 'proceessedTca'.