### PR TITLE
[BUGFIX] TCA default showitem

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -7,13 +7,10 @@ call_user_func(
     function () {
 
         $languageFilePrefix = 'LLL:EXT:fluidcontent/Resources/Private/Language/locallang.xlf:';
-        $frontendLanguageFilePrefix = 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:';
         if (version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), '8.0', '<')) {
             $tabsLanguageFilePrefix = 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.';
-            $categoryTabLabel = 'LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category:category';
         } else {
             $tabsLanguageFilePrefix = 'LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:';
-            $categoryTabLabel = $tabsLanguageFilePrefix . 'categories';
         }
 
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
@@ -38,19 +35,10 @@ call_user_func(
 
         $GLOBALS['TCA']['tt_content']['ctrl']['useColumnsForDefaultValues'] .= ',tx_fed_fcefile';
         $GLOBALS['TCA']['tt_content']['ctrl']['requestUpdate'] .= ',tx_fed_fcefile';
-        $GLOBALS['TCA']['tt_content']['types']['fluidcontent_content']['showitem'] = '
-            --palette--;' . $frontendLanguageFilePrefix . 'palette.general;general,
-            --palette--;' . $frontendLanguageFilePrefix . 'palette.header;header,
-            --div--;' . $frontendLanguageFilePrefix . 'tabs.appearance, layout;' . $frontendLanguageFilePrefix . 'layout_formlabel,
-            --palette--; '. $frontendLanguageFilePrefix . 'palette.frames;frames,
-            --palette--;' . $frontendLanguageFilePrefix . 'palette.appearanceLinks;appearanceLinks,
-            --div--;' . $tabsLanguageFilePrefix . 'access,
-            --palette--;' . $frontendLanguageFilePrefix . ';visibility,
-            --palette--;' . $frontendLanguageFilePrefix . ':palette.access;access,
-            --div--;' . $categoryTabLabel . ', categories,
-            --div--;' . $tabsLanguageFilePrefix . 'extended,
-            --div--;LLL:EXT:flux/Resources/Private/Language/locallang.xlf:tt_content.tabs.relation, tx_flux_parent, tx_flux_column
-        ';
+
+        // use flux ContentTypeBuilder to create TCA for fluidcontent_content
+        $contentTypeBuilder = new \FluidTYPO3\Flux\Helper\ContentTypeBuilder();
+        $contentTypeBuilder->addBoilerplateTableConfiguration('fluidcontent_content');
 
         if (version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), '8.0', '>=')) {
             \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_content', ',--div--;' . $tabsLanguageFilePrefix . 'language, --palette--;;language,', 'fluidcontent_content', 'before:access');


### PR DESCRIPTION
\FluidTYPO3\Flux\Helper\ContentTypeBuilder::addBoilerplateTableConfiguration is used to create the TCA.

solves #388  and #387 

**Important:** for the right TCA in TYPO3 7.6 and 8 the PR https://github.com/FluidTYPO3/flux/pull/1333 is necessary 