### PR TITLE
[BUGFIX] avoid creating possibly many many duplicates in page TSConfig

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -254,7 +254,7 @@ class ConfigurationService extends FluxService implements SingletonInterface
      */
     protected function getAllRootTypoScriptTemplates()
     {
-        $condition = 'deleted = 0 AND hidden = 0 AND starttime <= :starttime AND (endtime = 0 OR endtime > :endtime)';
+        $condition = 'root=1 AND deleted = 0 AND hidden = 0 AND starttime <= :starttime AND (endtime = 0 OR endtime > :endtime)';
         $parameters = [
             ':starttime' => $GLOBALS['SIM_ACCESS_TIME'],
             ':endtime' => $GLOBALS['SIM_ACCESS_TIME']

--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -254,7 +254,7 @@ class ConfigurationService extends FluxService implements SingletonInterface
      */
     protected function getAllRootTypoScriptTemplates()
     {
-        $condition = 'root=1 AND deleted = 0 AND hidden = 0 AND starttime <= :starttime AND (endtime = 0 OR endtime > :endtime)';
+        $condition = 'root = 1 AND deleted = 0 AND hidden = 0 AND starttime <= :starttime AND (endtime = 0 OR endtime > :endtime)';
         $parameters = [
             ':starttime' => $GLOBALS['SIM_ACCESS_TIME'],
             ':endtime' => $GLOBALS['SIM_ACCESS_TIME']


### PR DESCRIPTION
If you have a big pagetree with many TypoScript +ext Templates, then the same pageTSConfig is added over and over again for each page containing an +ext template. 
In our case this resulted in 4.6 mb entry in cf_fluidcontent, which in turn caused the live DB to reject the entry resulting in fatal error in the backend.
As the method name suggests, it should be enough to add this pageTSConfig only to pages where the TypoScript template has the root flag.

A workaround we successfully used was to activate compression for the cache backend cf_fluidcontent.