### PR TITLE
#391: Use tab title for wizard tab instead of id

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -432,7 +432,7 @@ class ConfigurationService extends FluxService implements SingletonInterface
                 mod.wizards.newContentElement.wizardItems.%s.position = 0
                 ',
                 $tabId,
-                !empty($existingItems[$tabId]['header']) ? $existingItems[$tabId]['header'] : $tabId,
+                !empty($existingItems[$tabId]['header']) ? $existingItems[$tabId]['header'] : $tab['title'],
                 $tabId,
                 implode(',', array_keys($tab['elements'])),
                 $tabId


### PR DESCRIPTION
$tab['title'] is not used here ...