### PR TITLE
[TASK] Allow installation in TYPO3 CMS 8.7 LTS

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,7 +24,7 @@ $EM_CONF[$_EXTKEY] = array (
     'depends' =>
     array (
       'php' => '7.0.0-7.1.99',
-      'typo3' => '7.6.0-8.6.99',
+      'typo3' => '7.6.0-8.7.99',
       'flux' => '7.3.0-8.99.99',
     ),
     'conflicts' =>


### PR DESCRIPTION
The version constraint in ext_emconf prohibitted the installation
in 8.7.

Ref: https://github.com/FluidTYPO3/fluidcontent/pull/403#issuecomment-295747350