### PR TITLE
Support TYPO3 CMS subtree split packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,13 @@
     "description": "Create Flexible Content elements in pure fluid",
     "require": {
         "fluidtypo3/flux": "^7.3|^8.0|dev-development",
-        "typo3/cms": "^7.6|^8.4",
+        "typo3/cms-core": "^7.6|^8.4",
         "php": ">=7.0.0"
     },
     "require-dev": {
         "fluidtypo3/development": "^3.0",
-        "fluidtypo3/flux": "dev-development"
+        "fluidtypo3/flux": "dev-development",
+        "typo3/cms-fluid": "^8.7.10"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In order to support TYPO3 CMS subtree split packages, introduced with v9.0.0 and backported to v8.7.7, the _typo3/cms_ package must not be used as dependency.

Furthermore, since _helhum/typo3-composer-setup_ is crucial to an operative TYPO3 CMS installation when using subtree split packages, the minimum core version has to be raised to v8.7.10 while developing.

See also:
https://typo3.org/article/typo3-v900-launched/#c7785