### PR TITLE
[BUGFIX] WizardItemsHookSubscriber change to WizardItems

### DIFF
--- a/Classes/Hooks/WizardItemsHookSubscriber.php
+++ b/Classes/Hooks/WizardItemsHookSubscriber.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Fluidcontent\Hooks;
 use FluidTYPO3\Fluidcontent\Backend\ContentTypeFilter;
 use FluidTYPO3\Fluidcontent\Service\ConfigurationService;
 use FluidTYPO3\Flux\Form\FormInterface;
-use FluidTYPO3\Flux\Hooks\WizardItemsHookSubscriber as FluxWizardItemsHookSubscriber;
+use FluidTYPO3\Flux\Integration\HookSubscribers\WizardItems as FluxWizardItemsHookSubscriber;
 use TYPO3\CMS\Backend\Controller\ContentElement\NewContentElementController;
 use TYPO3\CMS\Backend\Wizard\NewContentElementWizardHookInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;


### PR DESCRIPTION
- to Add new Content in Backend
- Folder and Class has change in Flux 9.x